### PR TITLE
do not prefix path with / in every case of path not having / as a prefix

### DIFF
--- a/src/main/java/ch/ubique/openapi/SwaggerGenerator.java
+++ b/src/main/java/ch/ubique/openapi/SwaggerGenerator.java
@@ -375,7 +375,7 @@ public class SwaggerGenerator extends AbstractMojo {
                             ? wrapper.value()[0]
                             : wrapper.path().length > 0 ? wrapper.path()[0] : "";
             getLog().warn(path);
-            if (!path.startsWith("/")) {
+            if (!baseUrl.isEmpty() && !baseUrl.endsWith("/") && !path.startsWith("/")) {
                 path = baseUrl + "/" + path;
             } else {
                 path = baseUrl + path;


### PR DESCRIPTION
Consider the following:

```
@Controller
@Requestmapping("/v1/user")
class UserController {
    @GetMapping("")
    public List<User> getAll() {...}
    
    @GetMapping("/{userId}")
    public User getOne(@PathVariable Integer userId) {...}
}
```

In this case, the endpoint for `getAll` would be created in the swagger config as `/v1/user/`, even though the endpoint in the running application is `/v1/user`. 